### PR TITLE
Make generateProto compatible for Windows

### DIFF
--- a/src/generateProto.ts
+++ b/src/generateProto.ts
@@ -2,13 +2,19 @@ import { execSync } from "child_process";
 import { getFiles } from "./utils";
 
 export function generateProto(protoDir: string): void {
+  let protocFile = './node_modules/.bin/as-proto-gen';
+
+  if (process.platform === 'win32') {
+    protocFile = '.\\node_modules\\.bin\\as-proto-gen.cmd';
+  }
+
   const protoFiles = getFiles(protoDir, ".proto");
   protoFiles.map((protoFile) => {
     console.log(protoFile);
     execSync(
       [
         "yarn protoc",
-        "--plugin=protoc-gen-as=./node_modules/.bin/as-proto-gen",
+        `--plugin=protoc-gen-as=${protocFile}`,
         `--proto_path=${protoDir}`,
         `--as_out=${protoDir}`,
         protoFile,


### PR DESCRIPTION
This fix makes generateProto work on Windows. Now it results in this error:
```--as_out: protoc-gen-as: %1 is not a valid Win32 application.```
